### PR TITLE
No Hero Women Slaughter 

### DIFF
--- a/simulation/templates/template_unit_hero_cavalry_archer.xml
+++ b/simulation/templates/template_unit_hero_cavalry_archer.xml
@@ -17,6 +17,7 @@
         <LaunchPoint y="5"/>
       </Projectile>
       <PreferredClasses datatype="tokens">Human</PreferredClasses>
+      <RestrictedClasses datatype="tokens">FemaleCitizen</RestrictedClasses>
     </Ranged>
   </Attack>
   <Health>

--- a/simulation/templates/template_unit_hero_cavalry_axeman.xml
+++ b/simulation/templates/template_unit_hero_cavalry_axeman.xml
@@ -12,6 +12,7 @@
      <PrepareTime>300</PrepareTime>
      <RepeatTime>1250</RepeatTime>
      <PreferredClasses datatype="tokens">Unit+!Ship</PreferredClasses>
+     <RestrictedClasses datatype="tokens">FemaleCitizen</RestrictedClasses>
     </Melee>
   </Attack>
   <Identity>

--- a/simulation/templates/template_unit_hero_cavalry_crossbowman.xml
+++ b/simulation/templates/template_unit_hero_cavalry_crossbowman.xml
@@ -17,6 +17,7 @@
         <LaunchPoint y="3"/>
       </Projectile>
       <PreferredClasses datatype="tokens">Human</PreferredClasses>
+      <RestrictedClasses datatype="tokens">FemaleCitizen</RestrictedClasses>
     </Ranged>
   </Attack>
   <Health>

--- a/simulation/templates/template_unit_hero_cavalry_javelineer.xml
+++ b/simulation/templates/template_unit_hero_cavalry_javelineer.xml
@@ -18,6 +18,7 @@
         <LaunchPoint y="5"/>
       </Projectile>
       <PreferredClasses datatype="tokens">Human</PreferredClasses>
+      <RestrictedClasses datatype="tokens">FemaleCitizen</RestrictedClasses>
     </Ranged>
   </Attack>
   <Health>

--- a/simulation/templates/template_unit_hero_cavalry_maceman.xml
+++ b/simulation/templates/template_unit_hero_cavalry_maceman.xml
@@ -11,6 +11,7 @@
       <PrepareTime>350</PrepareTime>
       <RepeatTime>1100</RepeatTime>
       <PreferredClasses datatype="tokens">!Ship</PreferredClasses>
+      <RestrictedClasses datatype="tokens">FemaleCitizen</RestrictedClasses>
     </Melee>
   </Attack>
     <Resistance>

--- a/simulation/templates/template_unit_hero_cavalry_spearman.xml
+++ b/simulation/templates/template_unit_hero_cavalry_spearman.xml
@@ -17,6 +17,7 @@
       <PrepareTime>350</PrepareTime>
       <RepeatTime>1300</RepeatTime>
       <PreferredClasses datatype="tokens">Unit+!Ship</PreferredClasses>
+      <RestrictedClasses datatype="tokens">FemaleCitizen</RestrictedClasses>
     </Melee>
   </Attack>
   <Identity>

--- a/simulation/templates/template_unit_hero_cavalry_swordsman.xml
+++ b/simulation/templates/template_unit_hero_cavalry_swordsman.xml
@@ -17,6 +17,7 @@
         </BonusCavMelee>
       </Bonuses>
      <PreferredClasses datatype="tokens">Unit+!Ship</PreferredClasses>
+     <RestrictedClasses datatype="tokens">FemaleCitizen</RestrictedClasses>
     </Melee>
   </Attack>
   <Cost>

--- a/simulation/templates/template_unit_hero_elephant_melee.xml
+++ b/simulation/templates/template_unit_hero_elephant_melee.xml
@@ -20,6 +20,7 @@
       <PrepareTime>750</PrepareTime>
       <RepeatTime>1500</RepeatTime>
      <PreferredClasses datatype="tokens">!Ship</PreferredClasses>
+     <RestrictedClasses datatype="tokens">FemaleCitizen</RestrictedClasses>
     </Melee>
   </Attack>
   <Cost>

--- a/simulation/templates/template_unit_hero_infantry_archer.xml
+++ b/simulation/templates/template_unit_hero_infantry_archer.xml
@@ -17,6 +17,7 @@
         <LaunchPoint y="3"/>
       </Projectile>
       <PreferredClasses datatype="tokens">Human</PreferredClasses>
+      <RestrictedClasses datatype="tokens">FemaleCitizen</RestrictedClasses>
     </Ranged>
   </Attack>
   <Identity>

--- a/simulation/templates/template_unit_hero_infantry_axeman.xml
+++ b/simulation/templates/template_unit_hero_infantry_axeman.xml
@@ -11,6 +11,7 @@
       <PrepareTime>500</PrepareTime>
       <RepeatTime>1000</RepeatTime>
       <PreferredClasses datatype="tokens">Unit+!Ship</PreferredClasses>
+      <RestrictedClasses datatype="tokens">FemaleCitizen</RestrictedClasses>
     </Melee>
   </Attack>
   <Identity>

--- a/simulation/templates/template_unit_hero_infantry_crossbowman.xml
+++ b/simulation/templates/template_unit_hero_infantry_crossbowman.xml
@@ -17,6 +17,7 @@
         <LaunchPoint y="3"/>
       </Projectile>
       <PreferredClasses datatype="tokens">Human</PreferredClasses>
+      <RestrictedClasses datatype="tokens">FemaleCitizen</RestrictedClasses>
     </Ranged>
   </Attack>
   <Health>

--- a/simulation/templates/template_unit_hero_infantry_javelineer.xml
+++ b/simulation/templates/template_unit_hero_infantry_javelineer.xml
@@ -18,6 +18,7 @@
         <LaunchPoint y="3"/>
       </Projectile>
       <PreferredClasses datatype="tokens">Human</PreferredClasses>
+      <RestrictedClasses datatype="tokens">FemaleCitizen</RestrictedClasses>
     </Ranged>
   </Attack>
   <Identity>

--- a/simulation/templates/template_unit_hero_infantry_maceman.xml
+++ b/simulation/templates/template_unit_hero_infantry_maceman.xml
@@ -10,6 +10,7 @@
       <PrepareTime>500</PrepareTime>
       <RepeatTime>1000</RepeatTime>
       <PreferredClasses datatype="tokens">!Ship</PreferredClasses>
+      <RestrictedClasses datatype="tokens">FemaleCitizen</RestrictedClasses>
     </Melee>
   </Attack>
   <Identity>

--- a/simulation/templates/template_unit_hero_infantry_pikeman.xml
+++ b/simulation/templates/template_unit_hero_infantry_pikeman.xml
@@ -17,6 +17,7 @@
         </BonusCavMelee>
       </Bonuses>
       <PreferredClasses datatype="tokens">Human</PreferredClasses>
+      <RestrictedClasses datatype="tokens">FemaleCitizen</RestrictedClasses>
     </Melee>
   </Attack>
   <Identity>

--- a/simulation/templates/template_unit_hero_infantry_spearman.xml
+++ b/simulation/templates/template_unit_hero_infantry_spearman.xml
@@ -17,6 +17,7 @@
         </BonusCavMelee>
       </Bonuses>
       <PreferredClasses datatype="tokens">Unit+!Ship</PreferredClasses>
+      <RestrictedClasses datatype="tokens">FemaleCitizen</RestrictedClasses>
     </Melee>
   </Attack>
   <Identity>

--- a/simulation/templates/template_unit_hero_infantry_swordsman.xml
+++ b/simulation/templates/template_unit_hero_infantry_swordsman.xml
@@ -10,6 +10,7 @@
       <PrepareTime>375</PrepareTime>
       <RepeatTime>750</RepeatTime>
       <PreferredClasses datatype="tokens">Unit+!Ship</PreferredClasses>
+      <RestrictedClasses datatype="tokens">FemaleCitizen</RestrictedClasses>
     </Melee>
   </Attack>
   <Cost>


### PR DESCRIPTION
Added 
      <RestrictedClasses datatype="tokens">FemaleCitizen</RestrictedClasses>
to all heros;
thus they cannot attack women anymore (tested ingame, worked).